### PR TITLE
Add request example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # front-angular
+
+This repository includes an example script demonstrating how to send a POST request where the body contains a `Resquest` object with `groupId` and `artifactId` fields.
+
+To build the TypeScript source and run the script:
+
+```bash
+npm run build
+npm start
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "front-angular",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/send-request.js",
+    "test": "echo \"No tests specified\""
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/src/send-request.ts
+++ b/src/send-request.ts
@@ -1,0 +1,28 @@
+interface Resquest {
+  groupId: string;
+  artifactId: string;
+}
+
+export async function sendRequest(): Promise<void> {
+  const payload: Resquest = {
+    groupId: 'example.group',
+    artifactId: 'example-artifact'
+  };
+
+  const response = await fetch('https://example.com/api', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log('Response:', data);
+}
+
+sendRequest().catch(err => console.error(err));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "outDir": "dist",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add TypeScript script to send a request with `groupId` and `artifactId`
- document example usage in README
- add minimal project setup with `package.json` and `tsconfig.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68475c43b2008329b1b7a923e4dc5ed5