### PR TITLE
Add zip download example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ To build the TypeScript source and run the script:
 npm run build
 npm start
 ```
+
+An additional example, `src/download-zip.ts`, shows how to request a binary
+file from an API and save it locally. Build it in the same way and run using
+
+```bash
+node dist/download-zip.js
+```
 =======
 This project exposes a small proxy endpoint for development.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,20 @@
       "dependencies": {
         "axios": "^1.5.1",
         "express": "^4.18.2"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.19",
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
+      "integrity": "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/accepts": {
@@ -912,6 +926,27 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "test": "echo \"No tests specified\""
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
-
+    "typescript": "^5.4.5",
+    "@types/node": "^20.11.19"
+  },
   "main": "server.js",
   "license": "MIT",
   "dependencies": {
     "express": "^4.18.2",
     "axios": "^1.5.1"
-
   }
 }

--- a/src/download-zip.ts
+++ b/src/download-zip.ts
@@ -1,0 +1,15 @@
+import { writeFile } from 'fs/promises';
+
+export async function downloadZip(): Promise<void> {
+  const response = await fetch('https://example.com/file.zip');
+
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  await writeFile('downloaded.zip', buffer);
+  console.log('File saved as downloaded.zip');
+}
+
+downloadZip().catch(err => console.error(err));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "lib": ["ES2022", "DOM"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- fix JSON formatting for package.json
- install Node type definitions and lock dependencies
- ignore dist/ directory
- update README with instructions for `src/download-zip.ts`
- add TypeScript script to download a zip file
- configure TypeScript lib for Node fetch

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68475c9cf51c83298c2d05ac2d38dd33